### PR TITLE
Update for webpack 5 support

### DIFF
--- a/src/html-webpack-change-assets-extension-plugin.ts
+++ b/src/html-webpack-change-assets-extension-plugin.ts
@@ -14,7 +14,7 @@ export default class HtmlWebpackChangeAssetsExtensionPlugin {
         // HtmlWebpackPlugin 3
         const { hooks } = compilation
         beforeGenerationHook = hooks.htmlWebpackPluginBeforeHtmlGeneration
-      } else if (HtmlWebpackPlugin.version === 4) {
+      } else if (HtmlWebpackPlugin.version >= 4) {
         // HtmlWebpackPlugin >= 4
         const hooks = HtmlWebpackPlugin.getHooks(compilation)
         beforeGenerationHook = hooks.beforeAssetTagGeneration


### PR DESCRIPTION
The current strict check for version 4 of webpack is restricting this plugin to work with webpack 5. Webpack 5 also have hooks similar to webopack 4 and the cuurent code works seemlessly with webpack 5 post this change.